### PR TITLE
ci: add GitHub Actions workflows

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -25,6 +25,7 @@ Do not introduce alternative stacks (no npm/yarn/pip unless explicitly required)
 - `frontend/` — Svelte 5 app and assets
 - `backend/` — FastAPI app, Pydantic models, services, routers
 - `docker-compose.yml` — local orchestration
+- `.github/` — GitHub Actions workflows
 
 If you add new top-level paths, update this section.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v1
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          uv pip install -e ./backend ruff pytest
+      - name: Lint
+        run: uv run ruff check backend
+      - name: Format
+        run: uv run ruff format --check backend
+      - name: Test
+        run: uv run pytest -q
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: |
+          cd frontend
+          bun install
+      - name: Build
+        run: |
+          cd frontend
+          bun run build


### PR DESCRIPTION
## Summary
- run backend linting, formatting, and tests with uv
- build frontend using bun
- document `.github/` in repo map

## Testing
- `uv run ruff check .` *(fails: unused imports)*
- `uv run ruff format --check backend` *(fails: would reformat)*
- `uv run pytest -q`
- `(cd frontend && bun run build)`
- `(cd frontend && bun run lint)` *(fails: Script not found "lint")*
- `(cd frontend && bun run format)` *(fails: Script not found "format")*

------
https://chatgpt.com/codex/tasks/task_e_6898156ae8388326b35782e656c4d955