### PR TITLE
feat: add BottomSheet component

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -23,5 +23,3 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 
-/src/lib/components/ui/
-!/src/lib/components/ui/.gitkeep

--- a/frontend/src/lib/components/ui/BottomSheet.svelte
+++ b/frontend/src/lib/components/ui/BottomSheet.svelte
@@ -1,55 +1,12 @@
 <script lang="ts">
-	import { useEventListener, onClickOutside } from 'runed';
+	import Bottomsheet from '@devantic/diaper';
 
-	// Whether the sheet is visible. Can be controlled via bind:open
 	export let open = $state(false);
-
-	// expose close function for consumers
-	function close() {
-		open = false;
-	}
-
-	let sheet: HTMLElement;
-
-	// Close on escape key
-	useEventListener(
-		() => window,
-		'keydown',
-		(e: KeyboardEvent) => {
-			if (e.key === 'Escape') close();
-		}
-	);
-
-	// Close when clicking outside the sheet
-	onClickOutside(() => sheet, close);
 </script>
 
-<div
-	class="fixed inset-0 z-50 flex flex-col items-end justify-end transition pointer-events-none"
-	data-open={open}
->
-	<!-- overlay -->
-	<div
-		class="absolute inset-0 bg-black/50 opacity-0 transition-opacity duration-300"
-		class:opacity-100={open}
-		on:click={close}
-	/>
-
-	<!-- sheet panel -->
-	<div
-		bind:this={sheet}
-		class="relative w-full max-h-[90vh] rounded-t-xl bg-base-100 shadow-lg transform transition-transform duration-300 translate-y-full"
-		class:translate-y-0={open}
-		style="touch-action: none;"
-		role="dialog"
-		aria-modal="true"
-	>
-		<slot />
-	</div>
-</div>
-
-<style>
-	div[data-open='true'] {
-		pointer-events: auto;
-	}
-</style>
+<Bottomsheet bind:open closeOnBackdropTap class="bg-base-100!">
+	{#snippet header()}
+		<slot name="header" />
+	{/snippet}
+	<slot />
+</Bottomsheet>

--- a/frontend/src/lib/components/ui/BottomSheet.svelte
+++ b/frontend/src/lib/components/ui/BottomSheet.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import { useEventListener, onClickOutside } from 'runed';
+
+	// Whether the sheet is visible. Can be controlled via bind:open
+	export let open = $state(false);
+
+	// expose close function for consumers
+	function close() {
+		open = false;
+	}
+
+	let sheet: HTMLElement;
+
+	// Close on escape key
+	useEventListener(
+		() => window,
+		'keydown',
+		(e: KeyboardEvent) => {
+			if (e.key === 'Escape') close();
+		}
+	);
+
+	// Close when clicking outside the sheet
+	onClickOutside(() => sheet, close);
+</script>
+
+<div
+	class="fixed inset-0 z-50 flex flex-col items-end justify-end transition pointer-events-none"
+	data-open={open}
+>
+	<!-- overlay -->
+	<div
+		class="absolute inset-0 bg-black/50 opacity-0 transition-opacity duration-300"
+		class:opacity-100={open}
+		on:click={close}
+	/>
+
+	<!-- sheet panel -->
+	<div
+		bind:this={sheet}
+		class="relative w-full max-h-[90vh] rounded-t-xl bg-base-100 shadow-lg transform transition-transform duration-300 translate-y-full"
+		class:translate-y-0={open}
+		style="touch-action: none;"
+		role="dialog"
+		aria-modal="true"
+	>
+		<slot />
+	</div>
+</div>
+
+<style>
+	div[data-open='true'] {
+		pointer-events: auto;
+	}
+</style>

--- a/frontend/src/lib/components/ui/index.ts
+++ b/frontend/src/lib/components/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as BottomSheet } from './BottomSheet.svelte';


### PR DESCRIPTION
## Summary
- add Svelte bottom sheet component with runed hooks
- export BottomSheet from UI components

## Testing
- `bun run format`
- `bun run lint` *(fails: assets and stores have lint errors)*
- `bun run test` *(fails: Playwright browsers missing)*
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6898aadb98c883268aa42433b69ad25f