### PR TITLE
refactor: adopt runed state and hooks

### DIFF
--- a/frontend/src/lib/components/Canvas.svelte
+++ b/frontend/src/lib/components/Canvas.svelte
@@ -1,34 +1,28 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { browser } from '$app/environment';
 	import { Stage, Layer } from 'svelte-konva';
 	import ScreenFrame from './ScreenFrame.svelte';
-	import { screens, assetsByScreen, online } from '../stores';
+	import { screens } from '../stores';
 	import type { Screen as StoreScreen } from '../stores';
 	import { api } from '../api';
 	import { connectWS } from '../ws';
+	import { useEventListener, useResizeObserver } from 'runed';
 
-
-
-	let scale = 0.25; // stage zoom
-	let offset = { x: 0, y: 0 };
-	let panning = false;
-	let last = { x: 0, y: 0 };
-	// add a ref to the canvas container
+	let scale = $state(0.25); // stage zoom
+	let offset = $state({ x: 0, y: 0 });
+	let panning = $state(false);
+	let last = $state({ x: 0, y: 0 });
+	// ref to the canvas container
 	let container: HTMLElement;
-	let viewport = { width: 0, height: 0 };
+	let viewport = $state({ width: 0, height: 0 });
 
 	async function load() {
-			const sc = await api('/screens');
-			screens.set(sc as StoreScreen[]);
-		const all = await api('/assets');
-		// assets store filled indirectly in ScreenFrame via events or do it here if preferred
-		// We'll broadcast on initial GET too for simplicity: update locally
-		// but to keep simple, ScreenFrame will fetch per screen.
+		const sc = await api('/screens');
+		screens.set(sc as StoreScreen[]);
+		await api('/assets'); // assets handled per screen
 	}
 
 	function onWheel(e: WheelEvent) {
-		// only handle wheel inside the canvas container
 		if (!container || !(e.target instanceof Node) || !container.contains(e.target)) return;
 		e.preventDefault();
 		const factor = 1.05;
@@ -37,7 +31,6 @@
 	}
 
 	function onMouseDown(e: MouseEvent) {
-		// only start panning when inside the canvas container
 		if (!container || !(e.target instanceof Node) || !container.contains(e.target)) return;
 		panning = true;
 		last = { x: e.clientX, y: e.clientY };
@@ -54,47 +47,41 @@
 		panning = false;
 	}
 
+	if (typeof window !== 'undefined') {
+		useEventListener(window, 'wheel', onWheel, { passive: false });
+		useEventListener(window, 'mousedown', onMouseDown);
+		useEventListener(window, 'mousemove', onMouseMove);
+		useEventListener(window, 'mouseup', onMouseUp);
+		useResizeObserver(
+			() => container,
+			(entries) => {
+				const rect = entries[0].contentRect;
+				viewport = { width: rect.width, height: rect.height };
+			}
+		);
+	}
+
 	onMount(() => {
 		connectWS();
 		load();
-		if (browser) {
-			const updateViewport = () => {
-				viewport = { width: window.innerWidth, height: window.innerHeight };
-			};
-			updateViewport();
-			window.addEventListener('resize', updateViewport);
-			return () => window.removeEventListener('resize', updateViewport);
-		}
 	});
 </script>
 
-<!-- attach event listeners to window and gate them to the container -->
-<svelte:window
-	on:wheel={onWheel}
-	on:mousedown={onMouseDown}
-	on:mousemove={onMouseMove}
-	on:mouseup={onMouseUp}
-/>
-
-<section
-	class="w-full h-[calc(100vh-64px)]"
-	bind:this={container}
-	aria-label="Canvas area"
->
-			<Stage
-				config={{
+<section class="w-full h-[calc(100vh-64px)]" bind:this={container} aria-label="Canvas area">
+	<Stage
+		config={{
 			width: viewport.width,
-			height: Math.max(0, viewport.height - 64),
-					scaleX: scale,
-					scaleY: scale,
-					x: offset.x,
-					y: offset.y
-				}}
-			>
-				<Layer>
+			height: viewport.height,
+			scaleX: scale,
+			scaleY: scale,
+			x: offset.x,
+			y: offset.y
+		}}
+	>
+		<Layer>
 			{#each $screens as sc}
-						<ScreenFrame {sc} />
-					{/each}
-				</Layer>
-			</Stage>
+				<ScreenFrame {sc} />
+			{/each}
+		</Layer>
+	</Stage>
 </section>

--- a/frontend/src/lib/components/ScreenFrame.svelte
+++ b/frontend/src/lib/components/ScreenFrame.svelte
@@ -10,19 +10,17 @@
 	import type { KonvaMouseEvent } from 'svelte-konva';
 
 	export let sc: Screen;
-	let myAssets: Asset[] = [];
+	let myAssets = $derived($assetsByScreen.get(sc.id) || []);
 
 	async function load() {
 		const list: Asset[] = await api<Asset[]>(`/assets?screen_id=${sc.id}`);
 		for (const a of list) upsertAsset(a);
 	}
 
-	$: myAssets = $assetsByScreen.get(sc.id) || [];
-
 	// Drag the whole screen in canvas (moves its x,y)
-	let dragging = false;
-	let start = { x: 0, y: 0 };
-	let orig = { x: 0, y: 0 };
+	let dragging = $state(false);
+	let start = $state({ x: 0, y: 0 });
+	let orig = $state({ x: 0, y: 0 });
 	function onScreenDown(e: KonvaMouseEvent) {
 		dragging = true;
 		const { evt } = e.detail;
@@ -38,7 +36,7 @@
 	}
 	function onScreenUp(_e: KonvaMouseEvent) {
 		dragging = false;
-		if ($online)
+		if (online.current)
 			api(`/screens/${sc.id}`, { method: 'PUT', body: JSON.stringify({ x: sc.x, y: sc.y }) });
 	}
 

--- a/frontend/src/lib/components/Toolbar.svelte
+++ b/frontend/src/lib/components/Toolbar.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
-	import { online, screens } from '../stores';
+	import { online, theme } from '../stores';
 	import { api } from '../api';
-	let name = 'Screen';
-	let width = 1920;
-	let height = 1080;
+	import { Popover, PopoverTrigger, PopoverContent } from './ui/popover';
+	import { Moon, Sun } from '@lucide/svelte';
+	import { watch } from 'runed';
+
+	let name = $state('Screen');
+	let width = $state(1920);
+	let height = $state(1080);
+	let dark = $state(theme.current === 'dark');
+
+	watch(dark, (d) => (theme.current = d ? 'dark' : 'light'));
+	watch(theme, (t) => (dark = t === 'dark'));
+
 	function addScreen() {
 		api('/screens', { method: 'POST', body: JSON.stringify({ name, width, height }) });
 	}
@@ -14,16 +23,34 @@
 	<div class="flex gap-2 items-center">
 		<label class="label cursor-pointer gap-2">
 			<span class="label-text">Offline Mode</span>
-			<input type="checkbox" class="toggle" bind:checked={$online} />
+			<input type="checkbox" class="toggle" bind:checked={online.current} />
+		</label>
+		<label class="swap swap-rotate">
+			<input type="checkbox" class="theme-controller" value="dark" bind:checked={dark} />
+			<Sun class="swap-off h-5 w-5" />
+			<Moon class="swap-on h-5 w-5" />
 		</label>
 		<div class="divider divider-horizontal"></div>
-		<div class="form-control">
-			<div class="input-group">
-				<input class="input input-bordered w-40" placeholder="Name" bind:value={name} />
-				<input class="input input-bordered w-28" type="number" bind:value={width} />
-				<input class="input input-bordered w-28" type="number" bind:value={height} />
-				<button class="btn btn-primary" on:click={addScreen}>Add Screen</button>
-			</div>
-		</div>
+		<Popover let:open>
+			<PopoverTrigger>
+				<button class="btn btn-primary">New Screen</button>
+			</PopoverTrigger>
+			<PopoverContent class="bg-base-200 rounded-box w-72 p-4 space-y-2">
+				<input class="input input-bordered w-full" placeholder="Name" bind:value={name} />
+				<div class="flex gap-2">
+					<input class="input input-bordered w-1/2" type="number" bind:value={width} />
+					<input class="input input-bordered w-1/2" type="number" bind:value={height} />
+				</div>
+				<button
+					class="btn btn-primary w-full"
+					on:click={() => {
+						addScreen();
+						open = false;
+					}}
+				>
+					Add
+				</button>
+			</PopoverContent>
+		</Popover>
 	</div>
 </div>

--- a/frontend/src/lib/components/assets/ImageAsset.svelte
+++ b/frontend/src/lib/components/assets/ImageAsset.svelte
@@ -7,9 +7,9 @@
 
 	export let a: any; // ImageAsset
 	let htmlImage: HTMLImageElement;
-	let isDragging = false;
-	let start = { x: 0, y: 0 };
-	let orig = { x: 0, y: 0 };
+	let isDragging = $state(false);
+	let start = $state({ x: 0, y: 0 });
+	let orig = $state({ x: 0, y: 0 });
 
 	onMount(() => {
 		htmlImage = new window.Image();
@@ -33,7 +33,7 @@
 	async function onUp() {
 		isDragging = false;
 		upsertAsset(a);
-		if ($online)
+		if (online.current)
 			await api(`/assets/${a.id}`, { method: 'PUT', body: JSON.stringify({ x: a.x, y: a.y }) });
 	}
 </script>

--- a/frontend/src/lib/components/assets/TextAsset.svelte
+++ b/frontend/src/lib/components/assets/TextAsset.svelte
@@ -5,9 +5,9 @@
 	import type { KonvaMouseEvent } from 'svelte-konva';
 
 	export let a: any; // TextAsset
-	let isDragging = false;
-	let start = { x: 0, y: 0 };
-	let orig = { x: 0, y: 0 };
+	let isDragging = $state(false);
+	let start = $state({ x: 0, y: 0 });
+	let orig = $state({ x: 0, y: 0 });
 
 	function onDown(e: KonvaMouseEvent) {
 		isDragging = true;
@@ -25,7 +25,7 @@
 	async function onUp() {
 		isDragging = false;
 		upsertAsset(a);
-		if ($online)
+		if (online.current)
 			await api(`/assets/${a.id}`, { method: 'PUT', body: JSON.stringify({ x: a.x, y: a.y }) });
 	}
 </script>

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -1,4 +1,5 @@
-import { writable, derived, get } from 'svelte/store';
+import { writable, derived } from 'svelte/store';
+import { PersistedState } from 'runed';
 
 export type Screen = {
 	id: string;
@@ -37,7 +38,10 @@ export type Asset = ImageAsset | TextAsset;
 
 export const screens = writable<Screen[]>([]);
 export const assets = writable<Asset[]>([]);
-export const online = writable<boolean>(true); // Offline Mode toggle
+// Persist the offline mode preference across sessions
+export const online = new PersistedState<boolean>('online', true);
+// Persist the selected theme across sessions
+export const theme = new PersistedState<string>('theme', 'light');
 export const selected = writable<string | null>(null);
 
 export const screensById = derived(screens, ($s) => new Map($s.map((sc) => [sc.id, sc])));

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
 	import '../app.css';
 	import favicon from '$lib/assets/favicon.svg';
-    import { ModeWatcher } from "mode-watcher";
+	import { ModeWatcher } from 'mode-watcher';
+	import { theme } from '$lib/stores';
+	import { watch } from 'runed';
 
 	let { children } = $props();
+
+	document.documentElement.setAttribute('data-theme', theme.current);
+	watch(theme, (t) => document.documentElement.setAttribute('data-theme', t));
 </script>
 
 <svelte:head>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -4,12 +4,12 @@
 	import { api, uploadFile } from '../lib/api';
 	import { online, upsertAsset, screens, type Asset } from '../lib/stores';
 
-	let hover = false;
+	let hover = $state(false);
 
 	async function onDrop(e: DragEvent) {
 		e.preventDefault();
 		hover = false;
-		if (!$online) return; // keep local only? For now, require online to upload
+		if (!online.current) return; // keep local only? For now, require online to upload
 		const files = e.dataTransfer?.files;
 		if (!files) return;
 		for (const file of Array.from(files)) {


### PR DESCRIPTION
## Summary
- use Runed `PersistedState` for offline flag
- refactor Toolbar, assets and Canvas components to Svelte 5 runes and DaisyUI inputs
- simplify ScreenFrame with `$derived` state
- persist theme and expose DaisyUI theme toggle with a shadcn popover for adding screens

## Testing
- `npm test` *(hangs; after interrupt reports 0 tests run)*
- `npm run lint` *(fails: Code style issues found in 70 files)*

------
https://chatgpt.com/codex/tasks/task_e_6898c5c2594883268018a011995250f0